### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/tech/shiker/assistant/call/BlogConstants.java
+++ b/src/main/java/tech/shiker/assistant/call/BlogConstants.java
@@ -5,13 +5,13 @@ public class BlogConstants {
 
     public static final String AI = "tool.message.ai";
 
-    public static final String BLOG_URL = "tSaqBcj9kLXMBb+1RdR3P5y9BXkob4yuGeMyt507gzeo+msddErwMBoIZL2mSc1d";
+    public static final String BLOG_URL = "1Hj+O9KcQK2fG9N5vmkhPPo/EJY8EaJC9b1NJ6u/Mwmi4Xh0Rlvf1feZyIR8UPLcG20xi+vL3KJ2D2lACYgV0ih+jW4L2R4=";
 
-    public static final String SITE_URL = "tSaqBcj9kLXMBb+1RdR3P1tcuAgfCGxKalkRSqHDsVw=";
+    public static final String SITE_URL = "pl3Vw94vul+Nm9aIC+bO63z9ufmREQFKoPlvbOmc0/vqTUOTeiGoTEikElkMlVg=";
 
-    public static final String AI_URL = "49X98Aj41BXRbIrb8idA0QVJ2S21HRsSalaeszl10vHQ1SUZlmJdhEngXID8vAGh3NOw5S5CZ8f+oV2MjABlTZDVxrd90j0yBmNGG26eH9A=";
+    public static final String AI_URL = "UWumrwNI8I23xcrvy96rQ9YFUTFgvqn/r5Hv/7y20KBbrkGwG2GsIkcziZsrpmqz8lkbkx3LuSMkYjJUxExyicyKRFmH+3xOE1PSto3D49KIMyJnruIIcG7o60FxsCJlIowCHJRsbKP3";
 
-    public static final String NONCE = "bkRBE27RfM3/qngGxeDq1Q==";
+    public static final String NONCE = "/NRzVdIC7wyYaxhT/9kAcIAszg/92HkDYRkViSdXEYYpKg==";
 
     public static final String SITE = "shiker.tech";
 }

--- a/src/main/java/tech/shiker/assistant/util/AESDecrypt.java
+++ b/src/main/java/tech/shiker/assistant/util/AESDecrypt.java
@@ -16,13 +16,21 @@ public class AESDecrypt {
     public static String decrypt(String base64EncryptedText, String key) throws Exception {
         // 转换密钥
         SecretKeySpec secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
-        // 获取 Cipher 实例（ECB 模式 + PKCS5Padding）
-        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-        cipher.init(Cipher.DECRYPT_MODE, secretKey);
+        // 获取 Cipher 实例（GCM 模式 + NoPadding）
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         // 解码 base64
         byte[] encryptedBytes = Base64.getDecoder().decode(base64EncryptedText);
+        // 提取 IV（假设 IV 是前 12 字节）
+        byte[] iv = new byte[12];
+        System.arraycopy(encryptedBytes, 0, iv, 0, 12);
+        // 提取实际加密数据
+        byte[] cipherText = new byte[encryptedBytes.length - 12];
+        System.arraycopy(encryptedBytes, 12, cipherText, 0, cipherText.length);
+        // 初始化 Cipher
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmSpec);
         // 解密
-        byte[] originalBytes = cipher.doFinal(encryptedBytes);
+        byte[] originalBytes = cipher.doFinal(cipherText);
         return new String(originalBytes, StandardCharsets.UTF_8);
     }
 

--- a/src/main/java/tech/shiker/assistant/util/AESDecrypt.java
+++ b/src/main/java/tech/shiker/assistant/util/AESDecrypt.java
@@ -1,17 +1,19 @@
 package tech.shiker.assistant.util;
 
 import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class AESDecrypt {
+
     /**
      * 虽然解密了也没啥用，但还是加个密吧
-     * @param base64EncryptedText
-     * @param key
-     * @return
-     * @throws Exception
+     * @param base64EncryptedText  base64EncryptedText
+     * @param key key
+     * @return String
+     * @throws Exception Exception
      */
     public static String decrypt(String base64EncryptedText, String key) throws Exception {
         // 转换密钥


### PR DESCRIPTION
Potential fix for [https://github.com/shiker1996/orange-assistant/security/code-scanning/2](https://github.com/shiker1996/orange-assistant/security/code-scanning/2)

To fix the issue, we need to replace the insecure "AES/ECB/PKCS5Padding" mode with a secure mode like "AES/GCM/NoPadding". GCM mode provides both encryption and authentication, making it a robust choice for modern cryptographic needs. This change requires the use of an initialization vector (IV), which must be randomly generated for each encryption operation and passed along with the ciphertext for decryption.

In the decryption method, we will:
1. Update the `Cipher.getInstance` call to use "AES/GCM/NoPadding".
2. Extract the IV from the input ciphertext (assuming it was prepended during encryption).
3. Initialize the cipher with the extracted IV and the secret key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
